### PR TITLE
Fix price rounding to avoid exceeding tick precision

### DIFF
--- a/test_utils_round_price.py
+++ b/test_utils_round_price.py
@@ -1,0 +1,6 @@
+import pytest
+from utils import round_price
+
+def test_round_price_rounds_down():
+    assert round_price(1.2399, price_precision=2) == pytest.approx(1.23)
+    assert round_price(1.235, price_precision=2) == pytest.approx(1.23)

--- a/utils.py
+++ b/utils.py
@@ -21,8 +21,9 @@ def round_price(price: float,
         if step > 0:
             return math.floor(price / step) * step
     if price_precision is not None:
-        fmt = "{:0." + str(int(price_precision)) + "f}"
-        return float(fmt.format(price))
+        # Use floor to avoid rounding up which can exceed allowed price
+        factor = 10 ** int(price_precision)
+        return math.floor(price * factor) / factor
     return price
 
 # utils_stats.py  (או בכל קובץ משותף בבוט)


### PR DESCRIPTION
## Summary
- prevent `round_price` from rounding up to disallowed values by flooring at the requested precision
- add unit test covering price rounding behavior

## Testing
- `pytest test_utils_round_price.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68acb494f4d8832395782f0d4fdbf997